### PR TITLE
Update license, CLA and DCO descriptions

### DIFF
--- a/license/index.html
+++ b/license/index.html
@@ -55,31 +55,30 @@
 
           <p>OpenVDB is released under the <a href="http://www.mozilla.org/MPL/2.0/"
           target="_blank">Mozilla Public License Version 2.0</a>, which is a free, open source,
-          and detailed software license developed and maintained by the Mozilla Foundation.
-          It is a hybrid of the modified
-          <a href="http://en.wikipedia.org/wiki/Modified_BSD_license" target="_blank">
-          BSD license</a> and the <a href="http://en.wikipedia.org/wiki/GNU_General_Public_License"
-          target="_blank">GNU General Public License</a> (GPL) that seeks to balance the concerns
-          of proprietary and open source developers.</p>
-
-
+          and detailed software license developed and maintained by the Mozilla Foundation. For
+          more information about this license, see the <a href="https://www.mozilla.org/en-US/MPL/" target="_blank">Mozilla FAQ</a>.</p>
+          
+          The trademarks of any contributor to this project may not be used in association with
+          the project without the contributor's express permission.
 
           <h2>Contributor License Agreement</h2>
 
-          <p>Developers who wish to contribute code to be considered for inclusion in the OpenVDB
-          distribution must first complete this
-          <a href="../download/OpenVDBContributorLicenseAgreement.pdf" target="_blank">
-          Contributor License Agreement</a> and submit it to
-          <a href="mailto:openvdb@gmail.com">openvdb@gmail.com</a>.
-          We prefer code submissions in the form of pull requests to the
-          <a href="https://github.com/AcademySoftwareFoundation/openvdb"
-          target="_blank">OpenVDB GitHub repository</a>.
-          All code should adhere to the OpenVDB
+          <p>Developers who wish to contribute code to be considered for inclusion
+          in the OpenVDB distribution must first be authorized under a signed Contributor
+          License Agreement. The signature and authorization process is managed via
+          the Linux Foundation's EasyCLA system, to handle the different CLAs depending
+          on whether you are contributing on your own behalf or on behalf of your
+          employer. The EasyCLA process will begin the first time you submit a PR
+          to the project.</p>
+          
+          <h2>DCO sign-offs</h2>
+
+          <p>All code should adhere to the OpenVDB
           <a href="../documentation/doxygen/codingStyle.html">coding standards</a>,
           and <i>every commit must be signed off</i>.
           That is, every commit log message must include a &ldquo;<tt>Signed-off-by</tt>&rdquo;
           line (generated, for example, with &ldquo;<tt>git commit --signoff</tt>&rdquo;),
-          indicating that the committer wrote the code and has the right to release it under the
+          indicating that the contributor has the right to release it under the
           <a href="http://www.mozilla.org/MPL/2.0/" target="_blank">MPL&nbsp;2.0</a> license.
           See&nbsp;<a href="http://developercertificate.org/"
           target="_blank">http://developercertificate.org/</a> for more information


### PR DESCRIPTION
Update the website text describing the project's license and CLA, and clarify the DCO process.

Signed-off-by: Steve Winslow <swinslow@linuxfoundation.org>