### PR TITLE
Fix S3 file path for artifacts

### DIFF
--- a/documentation/index.html
+++ b/documentation/index.html
@@ -64,23 +64,23 @@
           <h2>SIGGRAPH 2015 course</h2>
 
           <p>Download the presentation slides (PDF) from the SIGGRAPH 2015 OpenVDB course:
-          <br></br> <a href="https://artifacts.aswf.io/releases/io/aswf/openvdb/openvdb_introduction_2015/1.0.0/openvdb_introduction_2015-1.0.0.pdf">Introduction
+          <br></br> <a href="https://artifacts.aswf.io/io/aswf/openvdb/openvdb_introduction_2015/1.0.0/openvdb_introduction_2015-1.0.0.pdf">Introduction
           and fundamentals of the data structure</a>
-          </br> <a href="https://artifacts.aswf.io/releases/io/aswf/openvdb/openvdb_houdini_2015/1.0.0/openvdb_houdini_2015-1.0.0.pdf">Adoption in Houdini</a>
-          </br> <a href="https://artifacts.aswf.io/releases/io/aswf/openvdb/openvdb_production_2015/1.0.0/openvdb_production_2015-1.0.0.pdf">Production examples from DreamWorks Animation</a>
-          </br> <a href="https://artifacts.aswf.io/releases/io/aswf/openvdb/openvdb_particle_storage_2015/1.0.0/openvdb_particle_storage_2015-1.0.0.pdf">Advanced applications to particle storage at Double Negative</a>
+          </br> <a href="https://artifacts.aswf.io/io/aswf/openvdb/openvdb_houdini_2015/1.0.0/openvdb_houdini_2015-1.0.0.pdf">Adoption in Houdini</a>
+          </br> <a href="https://artifacts.aswf.io/io/aswf/openvdb/openvdb_production_2015/1.0.0/openvdb_production_2015-1.0.0.pdf">Production examples from DreamWorks Animation</a>
+          </br> <a href="https://artifacts.aswf.io/io/aswf/openvdb/openvdb_particle_storage_2015/1.0.0/openvdb_particle_storage_2015-1.0.0.pdf">Advanced applications to particle storage at Double Negative</a>
           </p>
 
           <h2>SIGGRAPH 2013 course</h2>
 
           <p>Download the presentation slides (PDF) from the SIGGRAPH 2013 OpenVDB course:
-          <br></br> <a href="https://artifacts.aswf.io/releases/io/aswf/openvdb/openvdb_introduction_2013/1.0.0/openvdb_introduction_2013-1.0.0.pdf">Introduction
+          <br></br> <a href="https://artifacts.aswf.io/io/aswf/openvdb/openvdb_introduction_2013/1.0.0/openvdb_introduction_2013-1.0.0.pdf">Introduction
           and fundamentals of the data structure</a>
-          </br> <a href="https://artifacts.aswf.io/releases/io/aswf/openvdb/openvdb_toolset_2013/1.0.0/openvdb_toolset_2013-1.0.0.pdf">Overview of toolset</a>
-          </br> <a href="https://artifacts.aswf.io/releases/io/aswf/openvdb/openvdb_production_2013/1.0.0/openvdb_production_2013-1.0.0.pdf">Production
+          </br> <a href="https://artifacts.aswf.io/io/aswf/openvdb/openvdb_toolset_2013/1.0.0/openvdb_toolset_2013-1.0.0.pdf">Overview of toolset</a>
+          </br> <a href="https://artifacts.aswf.io/io/aswf/openvdb/openvdb_production_2013/1.0.0/openvdb_production_2013-1.0.0.pdf">Production
           examples from DreamWorks Animation</a>
-          </br> <a href="https://artifacts.aswf.io/releases/io/aswf/openvdb/openvdb_fluids_2013/1.0.0/openvdb_fluids_2013-1.0.0.pdf">Adoption in fluid tools at Digital Domain</a>
-          </br> <a href="https://artifacts.aswf.io/releases/io/aswf/openvdb/openvdb_houdini_2013/1.0.0/openvdb_houdini_2013-1.0.0.pdf">Adoption in Houdini</a>
+          </br> <a href="https://artifacts.aswf.io/io/aswf/openvdb/openvdb_fluids_2013/1.0.0/openvdb_fluids_2013-1.0.0.pdf">Adoption in fluid tools at Digital Domain</a>
+          </br> <a href="https://artifacts.aswf.io/io/aswf/openvdb/openvdb_houdini_2013/1.0.0/openvdb_houdini_2013-1.0.0.pdf">Adoption in Houdini</a>
           </p>
 
 
@@ -138,7 +138,7 @@
           <p>J. Budsberg, M. Losure, K. Museth, and M. Baer,
           <a href="http://ken.museth.org/Publications_files/Budsberg-etal_DigiPro13.pdf"
             target="_blank">&ldquo;Liquids in &lsquo;The Croods&rsquo;&rdquo;</a>, <i>
-            ACM DigiPro 2013 Short Paper</i>. <a href="https://artifacts.aswf.io/releases/io/aswf/openvdb/liquids_in_the_croods_digipro2013/1.0.0/liquids_in_the_croods_digipro2013-1.0.0.pdf">DigiPro Presentation</a></p>
+            ACM DigiPro 2013 Short Paper</i>. <a href="https://artifacts.aswf.io/io/aswf/openvdb/liquids_in_the_croods_digipro2013/1.0.0/liquids_in_the_croods_digipro2013-1.0.0.pdf">DigiPro Presentation</a></p>
 
           <p>B. Miller, K. Museth, D. Penney and N. Bin Zafar,
           <a href="http://research.dreamworks.com/papers/PussInBoots_Clouds_DWA_2012.pdf"
@@ -156,13 +156,13 @@
 
           <h3>Press Releases</h3>
 
-          <p><a href="https://artifacts.aswf.io/releases/io/aswf/openvdb/DWA_News_2013_4_12_OpenVDB/1.0.0/DWA_News_2013_4_12_OpenVDB-1.0.0.pdf"
+          <p><a href="https://artifacts.aswf.io/io/aswf/openvdb/DWA_News_2013_4_12_OpenVDB/1.0.0/DWA_News_2013_4_12_OpenVDB-1.0.0.pdf"
           target="_blank">&ldquo;DreamWorks Animation&rsquo;s OpenVDB 1 ushers in a
           new era of volumetric storage and processing&rdquo;</a>, DreamWorks
           Animation, April 12,
           2013.</p>
 
-          <p><a href="https://artifacts.aswf.io/releases/io/aswf/openvdb/DWA_News_2012_8_3_OpenVDB/1.0.0/DWA_News_2012_8_3_OpenVDB-1.0.0.pdf"
+          <p><a href="https://artifacts.aswf.io/io/aswf/openvdb/DWA_News_2012_8_3_OpenVDB/1.0.0/DWA_News_2012_8_3_OpenVDB-1.0.0.pdf"
           target="_blank">&ldquo;DreamWorks Animation Releases Proprietary
           Volumetric Format OpenVDB to Open Source Community&rdquo;</a>,
           DreamWorks Animation, August 3, 2012.</p>

--- a/download/index.html
+++ b/download/index.html
@@ -123,7 +123,7 @@
           narrow-band level sets and fog volumes. More importantly, it presents recommended
           workflows for common tasks like particle surfacing, polygon conversion, fracturing,
           filtering, resampling, etc.
-          <p><a href="https://artifacts.aswf.io/releases/io/aswf/openvdb/houdini_examples.hip/1.0.0/houdini_examples.hip-1.0.0.zip">Houdini Examples zip</a>
+          <p><a href="https://artifacts.aswf.io/io/aswf/openvdb/houdini_examples.hip/1.0.0/houdini_examples.hip-1.0.0.zip">Houdini Examples zip</a>
             <i> - Jun 1 2017</i></p>
         </div> <!-- end section -->
 
@@ -133,7 +133,7 @@
           <p>OpenVDB includes a small number of Maya nodes, primarily for conversion
           of geometry to and from OpenVDB volumes and for visualization of volumes.
           This archive contains several example scene files that demonstrate how to use the nodes.
-          <p><a href="https://artifacts.aswf.io/releases/io/aswf/openvdb/maya_examples/1.0.0/maya_examples-1.0.0.zip">Maya Examples zip</a>
+          <p><a href="https://artifacts.aswf.io/io/aswf/openvdb/maya_examples/1.0.0/maya_examples-1.0.0.zip">Maya Examples zip</a>
             <i> - Aug 8 2016</i></p>
         </div> <!-- end section -->
 
@@ -150,101 +150,101 @@
 
             <br>
 
-            <a href="https://artifacts.aswf.io/releases/io/aswf/openvdb/models/armadillo.vdb/1.0.0/armadillo.vdb-1.0.0.zip" class="img-button" id="img-armadillo">
+            <a href="https://artifacts.aswf.io/io/aswf/openvdb/models/armadillo.vdb/1.0.0/armadillo.vdb-1.0.0.zip" class="img-button" id="img-armadillo">
                 <span><h3>armadillo.vdb</h3> <p>Voxel resolution </br> 1276&times;1519&times;116</p>
                 <p>File size 34 MB </p> </span></a>
 
-            <a href="https://artifacts.aswf.io/releases/io/aswf/openvdb/models/buddha.vdb/1.0.0/buddha.vdb-1.0.0.zip" class="img-button" id="img-buddha">
+            <a href="https://artifacts.aswf.io/io/aswf/openvdb/models/buddha.vdb/1.0.0/buddha.vdb-1.0.0.zip" class="img-button" id="img-buddha">
                 <span><h3>buddha.vdb</h3> <p>Voxel resolution </br> 541&times;1309&times;541</p>
                 <p>File size 27 MB </p> </span></a>
 
-            <a href="https://artifacts.aswf.io/releases/io/aswf/openvdb/models/bunny.vdb/1.0.0/bunny.vdb-1.0.0.zip" class="img-button" id="img-bunny">
+            <a href="https://artifacts.aswf.io/io/aswf/openvdb/models/bunny.vdb/1.0.0/bunny.vdb-1.0.0.zip" class="img-button" id="img-bunny">
                 <span><h3>bunny.vdb</h3> <p>Voxel resolution </br> 628&times;621&times;489</p>
                 <p>File size 11 MB </p> </span></a>
 
-            <a href="https://artifacts.aswf.io/releases/io/aswf/openvdb/models/bunny_cloud.vdb/1.0.0/bunny_cloud.vdb-1.0.0.zip" class="img-button" id="img-bunny_cloud">
+            <a href="https://artifacts.aswf.io/io/aswf/openvdb/models/bunny_cloud.vdb/1.0.0/bunny_cloud.vdb-1.0.0.zip" class="img-button" id="img-bunny_cloud">
                 <span><h3>bunny_cloud.vdb</h3> <p>Voxel resolution </br> 577&times;572&times;438</p>
                 <p>File size 74 MB </p> </span></a>
 
-            <a href="https://artifacts.aswf.io/releases/io/aswf/openvdb/models/crawler.vdb/1.0.0/crawler.vdb-1.0.0.zip" class="img-button" id="img-crawler">
+            <a href="https://artifacts.aswf.io/io/aswf/openvdb/models/crawler.vdb/1.0.0/crawler.vdb-1.0.0.zip" class="img-button" id="img-crawler">
                 <span><h3>crawler.vdb</h3> <p>Voxel resolution </br> 2619&times;511&times;2149</p>
                 <p>File size 64 MB </p> </span></a>
 
-            <a href="https://artifacts.aswf.io/releases/io/aswf/openvdb/models/cube.vdb/1.0.0/cube.vdb-1.0.0.zip" class="img-button" id="img-box">
+            <a href="https://artifacts.aswf.io/io/aswf/openvdb/models/cube.vdb/1.0.0/cube.vdb-1.0.0.zip" class="img-button" id="img-box">
                 <span><h3>cube.vdb</h3> <p>Voxel resolution </br> 225&times;225&times;225</p>
                 <p>File size 1 MB </p> </span></a>
 
-            <a href="https://artifacts.aswf.io/releases/io/aswf/openvdb/models/dragon.vdb/1.0.0/dragon.vdb-1.0.0.zip" class="img-button" id="img-dragon">
+            <a href="https://artifacts.aswf.io/io/aswf/openvdb/models/dragon.vdb/1.0.0/dragon.vdb-1.0.0.zip" class="img-button" id="img-dragon">
                 <span><h3>dragon.vdb</h3> <p>Voxel resolution </br> 2023&times;911&times;1347</p>
                 <p>File size 45 MB </p> </span></a>
 
-            <a href="https://artifacts.aswf.io/releases/io/aswf/openvdb/models/emu.vdb/1.0.0/emu.vdb-1.0.0.zip" class="img-button" id="img-emu">
+            <a href="https://artifacts.aswf.io/io/aswf/openvdb/models/emu.vdb/1.0.0/emu.vdb-1.0.0.zip" class="img-button" id="img-emu">
                 <span><h3>emu.vdb</h3> <p>Voxel resolution </br> 1481&times;2609&times;1843</p>
                 <p>File size 128 MB </p> </span></a>
 
-            <a href="https://artifacts.aswf.io/releases/io/aswf/openvdb/models/explosion.vdb/1.0.0/explosion.vdb-1.0.0.zip" class="img-button" id="img-explosion">
+            <a href="https://artifacts.aswf.io/io/aswf/openvdb/models/explosion.vdb/1.0.0/explosion.vdb-1.0.0.zip" class="img-button" id="img-explosion">
                 <span><h3>explosion.vdb</h3> <p>Voxel resolution </br> 201&times;272&times;230</p>
                 <p>File size 72 MB </p> </span></a>
 
-            <a href="https://artifacts.aswf.io/releases/io/aswf/openvdb/models/fire.vdb/1.0.0/fire.vdb-1.0.0.zip" class="img-button" id="img-fire">
+            <a href="https://artifacts.aswf.io/io/aswf/openvdb/models/fire.vdb/1.0.0/fire.vdb-1.0.0.zip" class="img-button" id="img-fire">
                 <span><h3>fire.vdb</h3> <p>Voxel resolution </br> 161&times;364&times;153</p>
                 <p>File size 23 MB </p> </span></a>
 
-            <a href="https://artifacts.aswf.io/releases/io/aswf/openvdb/models/icosahedron.vdb/1.0.0/icosahedron.vdb-1.0.0.zip" class="img-button" id="img-icosahedron">
+            <a href="https://artifacts.aswf.io/io/aswf/openvdb/models/icosahedron.vdb/1.0.0/icosahedron.vdb-1.0.0.zip" class="img-button" id="img-icosahedron">
                 <span><h3>icosahedron.vdb</h3> <p>Voxel resolution </br> 143&times;149&times;165</p>
                 <p>File size 1 MB </p> </span></a>
 
-            <a href="https://artifacts.aswf.io/releases/io/aswf/openvdb/models/iss.vdb/1.0.0/iss.vdb-1.0.0.zip" class="img-button" id="img-iss">
+            <a href="https://artifacts.aswf.io/io/aswf/openvdb/models/iss.vdb/1.0.0/iss.vdb-1.0.0.zip" class="img-button" id="img-iss">
                 <span><h3>iss.vdb</h3> <p>Voxel resolution </br> 4561&times;617&times;2999</p>
                 <p>File size 34 MB </p> </span></a>
 
-            <a href="https://artifacts.aswf.io/releases/io/aswf/openvdb/models/smoke1.vdb/1.0.0/smoke1.vdb-1.0.0.zip" class="img-button" id="img-smoke1">
+            <a href="https://artifacts.aswf.io/io/aswf/openvdb/models/smoke1.vdb/1.0.0/smoke1.vdb-1.0.0.zip" class="img-button" id="img-smoke1">
                 <span><h3>smoke1.vdb</h3> <p>Voxel resolution </br> 111&times;222&times;112</p>
                 <p>File size 2 MB </p> </span></a>
 
-            <a href="https://artifacts.aswf.io/releases/io/aswf/openvdb/models/smoke2.vdb/1.0.0/smoke2.vdb-1.0.0.zip" class="img-button" id="img-smoke2">
+            <a href="https://artifacts.aswf.io/io/aswf/openvdb/models/smoke2.vdb/1.0.0/smoke2.vdb-1.0.0.zip" class="img-button" id="img-smoke2">
                 <span><h3>smoke2.vdb</h3> <p>Voxel resolution </br> 191&times;610&times;178</p>
                 <p>File size 28 MB </p> </span></a>
 
-            <a href="https://artifacts.aswf.io/releases/io/aswf/openvdb/models/space.vdb/1.0.0/space.vdb-1.0.0.zip" class="img-button" id="img-space">
+            <a href="https://artifacts.aswf.io/io/aswf/openvdb/models/space.vdb/1.0.0/space.vdb-1.0.0.zip" class="img-button" id="img-space">
                 <span><h3>space.vdb</h3> <p>Voxel resolution </br> 32844&times;24702&times;9156</p>
                 <p>File size 242 MB </p> </span></a>
 
-            <a href="https://artifacts.aswf.io/releases/io/aswf/openvdb/models/sphere.vdb/1.0.0/sphere.vdb-1.0.0.zip" class="img-button" id="img-sphere">
+            <a href="https://artifacts.aswf.io/io/aswf/openvdb/models/sphere.vdb/1.0.0/sphere.vdb-1.0.0.zip" class="img-button" id="img-sphere">
                 <span><h3>sphere.vdb</h3> <p>Voxel resolution </br> 125&times;125&times;125</p>
                 <p>File size 1 MB </p> </span></a>
 
-            <a href="https://artifacts.aswf.io/releases/io/aswf/openvdb/models/torus.vdb/1.0.0/torus.vdb-1.0.0.zip" class="img-button" id="img-torus">
+            <a href="https://artifacts.aswf.io/io/aswf/openvdb/models/torus.vdb/1.0.0/torus.vdb-1.0.0.zip" class="img-button" id="img-torus">
                 <span><h3>torus.vdb</h3> <p>Voxel resolution </br> 299&times;299&times;103</p>
                 <p>File size 4 MB </p> </span></a>
 
-            <a href="https://artifacts.aswf.io/releases/io/aswf/openvdb/models/torus_knot.vdb/1.0.0/torus_knot.vdb-1.0.0.zip" class="img-button" id="img-helix">
+            <a href="https://artifacts.aswf.io/io/aswf/openvdb/models/torus_knot.vdb/1.0.0/torus_knot.vdb-1.0.0.zip" class="img-button" id="img-helix">
                 <span><h3>torus_knot.vdb</h3> <p>Voxel resolution </br> 1090&times;1119&times;577</p>
                 <p>File size 17 MB </p> </span></a>
 
-            <a href="https://artifacts.aswf.io/releases/io/aswf/openvdb/models/utahteapot.vdb/1.0.0/utahteapot.vdb-1.0.0.zip" class="img-button" id="img-utahteapot">
+            <a href="https://artifacts.aswf.io/io/aswf/openvdb/models/utahteapot.vdb/1.0.0/utahteapot.vdb-1.0.0.zip" class="img-button" id="img-utahteapot">
                 <span><h3>utahteapot.vdb</h3> <p>Voxel resolution </br> 981&times;463&times;617</p>
                 <p>File size 12 MB </p> </span></a>
 
-            <a href="https://artifacts.aswf.io/releases/io/aswf/openvdb/models/venusstatue.vdb/1.0.0/venusstatue.vdb-1.0.0.zip" class="img-button" id="img-venusstatue">
+            <a href="https://artifacts.aswf.io/io/aswf/openvdb/models/venusstatue.vdb/1.0.0/venusstatue.vdb-1.0.0.zip" class="img-button" id="img-venusstatue">
                 <span><h3>venusstatue.vdb</h3> <p>Voxel resolution </br> 336&times;1150&times;338</p>
                 <p>File size 20 MB </p> </span></a>
 
           <br><br>
 
-          <a href="https://artifacts.aswf.io/releases/io/aswf/openvdb/models/boat_points.vdb/1.0.0/boat_points.vdb-1.0.0.zip" class="img-button" id="img-boat_points">
+          <a href="https://artifacts.aswf.io/io/aswf/openvdb/models/boat_points.vdb/1.0.0/boat_points.vdb-1.0.0.zip" class="img-button" id="img-boat_points">
               <span><h3>boat_points.vdb</h3> <p>Voxel resolution </br> 211&times;63&times;381</p>
                   <p>File size 330 MB </p> </span></a>
 
-          <a href="https://artifacts.aswf.io/releases/io/aswf/openvdb/models/bunny_points.vdb/1.0.0/bunny_points.vdb-1.0.0.zip" class="img-button" id="img-bunny_points">
+          <a href="https://artifacts.aswf.io/io/aswf/openvdb/models/bunny_points.vdb/1.0.0/bunny_points.vdb-1.0.0.zip" class="img-button" id="img-bunny_points">
               <span><h4><br>bunny_points.vdb</h4> <p>Voxel resolution </br> 310&times;307&times;241</p>
                   <p>File size 307 MB </p> </span></a>
 
-          <a href="https://artifacts.aswf.io/releases/io/aswf/openvdb/models/sphere_points.vdb/1.0.0/sphere_points.vdb-1.0.0.zip" class="img-button" id="img-sphere_points">
+          <a href="https://artifacts.aswf.io/io/aswf/openvdb/models/sphere_points.vdb/1.0.0/sphere_points.vdb-1.0.0.zip" class="img-button" id="img-sphere_points">
               <span><h4><br>sphere_points.vdb</h4> <p>Voxel resolution </br> 17&times;17&times;17</p>
                   <p>File size 53 KB </p> </span></a>
 
-          <a href="https://artifacts.aswf.io/releases/io/aswf/openvdb/models/waterfall_points.vdb/1.0.0/waterfall_points.vdb-1.0.0.zip" class="img-button" id="img-waterfall_points">
+          <a href="https://artifacts.aswf.io/io/aswf/openvdb/models/waterfall_points.vdb/1.0.0/waterfall_points.vdb-1.0.0.zip" class="img-button" id="img-waterfall_points">
               <span><h5><br>waterfall_points.vdb</h5> <p>Voxel resolution </br> 611&times;670&times;637</p>
                   <p>File size 132 MB </p> </span></a>
 


### PR DESCRIPTION
The migration from Nexus to S3 dropped the releases filepath prefix.

Signed-off-by: Andrew Grimberg <agrimberg@linuxfoundation.org>