### PR TITLE
fixed type and edited text

### DIFF
--- a/index.html
+++ b/index.html
@@ -103,8 +103,8 @@
             <p>Highlights of this release:
             <ul>
                 <li>significant performance improvements to CSG operations with new parallel
-                breath-first algorithms and tools</li>
-                <li>pre-release of OpenVDB AX, an open source C++ library that provides a
+                breadth-first algorithms and tools</li>
+                <li>pre-release of OpenVDB AX, a C++ library that provides a
                 powerful and easy way of interacting with OpenVDB volume and point data</li>
                 <li>added support for matrix grids</li>
                 <li>various bug fixes and other improvements</li>


### PR DESCRIPTION
Signed-off-by: Ken <ken.museth@gmail.com>

Fixed the typo "breath-first" -> "breadth-first" and removed the redundant "open source" in the AX description