### PR TITLE
Fix mathematica download

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-*.zip filter=lfs diff=lfs merge=lfs -text

--- a/download/files/OpenVDBLink.nb.zip
+++ b/download/files/OpenVDBLink.nb.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5db19014f361b1898130aff864d6d0f1444a2590984d23906f609fd102d2dcea
-size 16524953


### PR DESCRIPTION
The current Mathematica notebook cannot be downloaded because it is stored as a git-lfs file. I'm changing it to a non-lfs tracked file so that it can be downloaded.