### PR TITLE
Fix the asset path in download page.

### DIFF
--- a/download/index.html
+++ b/download/index.html
@@ -217,8 +217,8 @@
                 <span><h3>iss.vdb</h3> <p>Voxel resolution </br> 4561&times;617&times;2999</p>
                 <p>File size 34 MB </p> </span></a>
 
-            <a href="https://media.githubusercontent.com/media/AcademySoftwareFoundation/openvdb-website/master/download/models/smoke1.vdb" class="img-button" id="img-smoke1">
-                <span><h3>smoke1.vdb</h3> <p>Voxel resolution </br> 111&times;222&times;112</p>
+            <a href="https://media.githubusercontent.com/media/AcademySoftwareFoundation/openvdb-website/master/download/models/smoke.vdb" class="img-button" id="img-smoke1">
+                <span><h3>smoke.vdb</h3> <p>Voxel resolution </br> 111&times;222&times;112</p>
                 <p>File size 2 MB </p> </span></a>
 
             <a href="https://media.githubusercontent.com/media/AcademySoftwareFoundation/openvdb-website/master/download/models/smoke2.vdb" class="img-button" id="img-smoke2">
@@ -237,8 +237,8 @@
                 <span><h3>torus.vdb</h3> <p>Voxel resolution </br> 299&times;299&times;103</p>
                 <p>File size 4 MB </p> </span></a>
 
-            <a href="https://media.githubusercontent.com/media/AcademySoftwareFoundation/openvdb-website/master/download/models/torus_knot.vdb" class="img-button" id="img-helix">
-                <span><h3>torus_knot.vdb</h3> <p>Voxel resolution </br> 1090&times;1119&times;577</p>
+            <a href="https://media.githubusercontent.com/media/AcademySoftwareFoundation/openvdb-website/master/download/models/torus_knot_helix.vdb" class="img-button" id="img-helix">
+                <span><h3>torus_knot_helix.vdb</h3> <p>Voxel resolution </br> 1090&times;1119&times;577</p>
                 <p>File size 17 MB </p> </span></a>
 
             <a href="https://media.githubusercontent.com/media/AcademySoftwareFoundation/openvdb-website/master/download/models/utahteapot.vdb" class="img-button" id="img-utahteapot">


### PR DESCRIPTION
Two assets in the openvdb website download page cannot be downloaded. The problem is that the links refer to the wrong `.vdb` file names

- `smoke1.vdb` should be `smoke.vdb`
- `torus_knot.vdb` should be `torus_knot_helix.vdb`

